### PR TITLE
Better Markdown syntax

### DIFF
--- a/koans-en.md
+++ b/koans-en.md
@@ -1,104 +1,104 @@
-#Kōans list
+# Kōans list
 
-##Ruby
+## Ruby
 - [http://rubykoans.com/](http://rubykoans.com/)
 - [https://github.com/neo/ruby_koans](https://github.com/neo/ruby_koans)
 - [https://github.com/sathish316/metaprogramming_koans](https://github.com/sathish316/metaprogramming_koans)
 
-##Python
+## Python
 - [https://github.com/gregmalcolm/python_koans](https://github.com/gregmalcolm/python_koans)
 
-##Clojure
+## Clojure
  - [https://github.com/functional-koans/clojure-koans](https://github.com/functional-koans/clojure-koans) 
-###core.logic
+### core.logic
  - [https://github.com/sritchie/core.logic-koans](https://github.com/sritchie/core.logic-koans)
-###ClojureScript
+### ClojureScript
  - [http://clojurescriptkoans.com/](http://clojurescriptkoans.com/)
 
-##Scala
+## Scala
  - [http://www.scalakoans.org/](http://www.scalakoans.org/) 
  - [https://github.com/rubbish/scala-koans](https://github.com/rubbish/scala-koans)
  - [https://github.com/sbt/sbt-koan](https://github.com/sbt/sbt-koan)
 
-##Groovy
+## Groovy
  - [http://groovykoans.org/](http://groovykoans.org/)
 
-##Lisp 
+## Lisp 
  - [https://github.com/google/lisp-koans](https://github.com/google/lisp-koans)
 
-##Angularjs
+## Angularjs
  - [https://github.com/bjpbakker/angular-koans](https://github.com/bjpbakker/angular-koans)
  
-##Backbone
+## Backbone
  - [https://github.com/larrymyers/backbone-koans](https://github.com/larrymyers/backbone-koans)
 
-##CoffeeScript
+## CoffeeScript
  - [https://github.com/sleepyfox/coffeescript-koans](https://github.com/sleepyfox/coffeescript-koans)
 
-##JavaScript
+## JavaScript
  - [https://github.com/liammclennan/JavaScript-Koans](https://github.com/liammclennan/JavaScript-Koans)
  - [https://github.com/mrdavidlaing/javascript-koans](https://github.com/mrdavidlaing/javascript-koans)
 
-##Go
+## Go
  - [https://github.com/cdarwin/go-koans](https://github.com/cdarwin/go-koans)
 
-##Git
+## Git
  - [http://gitimmersion.com/](http://gitimmersion.com/)
 
-##FSharp
+## FSharp
  - [https://github.com/ChrisMarinos/FSharpKoans](https://github.com/ChrisMarinos/FSharpKoans)
 
-##Dart 
+## Dart 
  - [https://github.com/butlermatt/dart_koans](https://github.com/butlermatt/dart_koans)
 
-##Perl
+## Perl
  - [https://github.com/forcedotcom/PerlKoans](https://github.com/forcedotcom/PerlKoans)
 
-##CSharp
+## CSharp
  - [https://bitbucket.org/srtsolutions/csharpkoans](https://bitbucket.org/srtsolutions/csharpkoans)
 
-##Objective-C 
+## Objective-C 
  - [https://github.com/joecannatti/Objective-C-Koans](https://github.com/joecannatti/Objective-C-Koans)
 
-##Java 
+## Java 
  - [https://github.com/matyb/java-koans](https://github.com/matyb/java-koans)
 
-##Haskell 
+## Haskell 
  - [https://github.com/HaskVan/HaskellKoans](https://github.com/HaskVan/HaskellKoans)
  - [https://github.com/tonymorris/course](https://github.com/tonymorris/course)
 
-##Erlang 
+## Erlang 
  - [https://github.com/patrickgombert/erlang-koans](https://github.com/patrickgombert/erlang-koans)
 
-##Elixir 
+## Elixir 
  - [https://github.com/seven1m/30-days-of-elixir](https://github.com/seven1m/30-days-of-elixir)
  
-##Lua
+## Lua
  - [https://github.com/kikito/lua_missions](https://github.com/kikito/lua_missions)
 
-##Neo4j
+## Neo4j
  - [https://github.com/jimwebber/neo4j-tutorial](https://github.com/jimwebber/neo4j-tutorial)
 
-##Mongodb
+## Mongodb
  - [https://github.com/chicagoruby/MongoDB_Koans](https://github.com/chicagoruby/MongoDB_Koans)
 
-##Reactjs
+## Reactjs
  - [https://github.com/arkency/reactjs_koans](https://github.com/arkency/reactjs_koans)
 
-##DotNet
+## DotNet
  - [https://github.com/CoryFoy/DotNetKoans](https://github.com/CoryFoy/DotNetKoans)
 
-##ColdFusion
+## ColdFusion
  - [https://github.com/bittersweetryan/ColdFusion-Koans](https://github.com/bittersweetryan/ColdFusion-Koans)
  
-##GNU Smalltalk
+## GNU Smalltalk
  - [https://github.com/sl4m/gnu_smalltalk_koans](https://github.com/sl4m/gnu_smalltalk_koans)
 
-##Prolog
+## Prolog
  - [https://github.com/araneforseti/prolog-koans](https://github.com/araneforseti/prolog-koans)
 
-##MyBatis
+## MyBatis
  - [https://github.com/quux00/mybatis-koans](https://github.com/quux00/mybatis-koans)
 
-##Bash
+## Bash
  - [https://github.com/marcinbunsch/bash_koans](https://github.com/marcinbunsch/bash_koans)


### PR DESCRIPTION
Some major Markdown parsers, like CommonMark and whatever drives [getawesomeness.com](http://getawesomeness.com/get/koans) , require a space between the `#` and header text.

Accepting this commit will allow these parsers to generate the proper header tags.