### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,12 @@ ________________________________
 
 > Kōans are a paradoxical anecdote or riddle, used in Zen Buddhism to demonstrate the inadequacy of _logical reasoning_ and to _provoke enlightenment_. 
 
-#Intro
+# Intro
 
 If you enjoy trying things out, and learning new languages, this list will help to do that.
 
-#Kōans list
+# Kōans list
  - [English](https://github.com/ahmdrefat/koans/blob/master/koans-en.md)
 
-#Get Help
+# Get Help
 [![githelp](https://dl.dropboxusercontent.com/u/32056767/githelp-badge.png "githelp")](https://githelp.io)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
